### PR TITLE
Switch site syntax highlighting to Highlight.js

### DIFF
--- a/css/syntax-dark.scss
+++ b/css/syntax-dark.scss
@@ -11,6 +11,7 @@
   --hljs-keyword: #f92672;
   --hljs-function: #ff79ff;
   --hljs-params: #fd971f;
+  --hljs-variable: #ae81ff;
   --hljs-comment: #404040;
 }
 
@@ -276,6 +277,94 @@ code span.vs {
 
 code span.wa {
   color: $quarto-hl-wa-color;
+}
+
+/* Highlight.js support */
+code.hljs,
+pre code.hljs {
+  background-color: var(--hljs-background, var(--color-code-bg));
+  color: var(--hljs-text, inherit);
+}
+
+pre code.hljs {
+  display: block;
+}
+
+.hljs::selection,
+.hljs ::selection {
+  background-color: var(--hljs-selection, rgba(255, 255, 255, 0.15));
+  color: inherit;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: var(--hljs-comment, var(--quarto-hl-co-color));
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst,
+.hljs-section {
+  color: var(--hljs-keyword, var(--quarto-hl-kw-color));
+}
+
+.hljs-title,
+.hljs-name,
+.hljs-attr,
+.hljs-attribute,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-type {
+  color: var(--hljs-title, var(--quarto-hl-fu-color));
+}
+
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+  color: var(--hljs-built_in, var(--quarto-hl-bu-color));
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-deletion,
+.hljs-meta,
+.hljs-meta .hljs-number {
+  color: var(--hljs-number, var(--quarto-hl-num-color));
+}
+
+.hljs-string,
+.hljs-doctag,
+.hljs-regexp,
+.hljs-link {
+  color: var(--hljs-string, var(--quarto-hl-st-color));
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-template-tag,
+.hljs-property {
+  color: var(--hljs-variable, var(--quarto-hl-va-color));
+}
+
+.hljs-function,
+.hljs-title .hljs-title,
+.hljs-function .hljs-title {
+  color: var(--hljs-function, var(--quarto-hl-fu-color));
+}
+
+.hljs-params {
+  color: var(--hljs-params, var(--quarto-hl-va-color));
+}
+
+.hljs-strong {
+  font-weight: 600;
+}
+
+.hljs-emphasis {
+  font-style: italic;
 }
 
 .prevent-inlining {

--- a/css/syntax-light.scss
+++ b/css/syntax-light.scss
@@ -154,6 +154,18 @@ $quarto-hl-wa-color: #da4453;
   --quarto-hl-va-color: $quarto-hl-va-color;
   --quarto-hl-vs-color: $quarto-hl-vs-color;
   --quarto-hl-wa-color: $quarto-hl-wa-color;
+  --hljs-selection: #d1e4f4;
+  --hljs-background: var(--color-code-bg);
+  --hljs-text: var(--color-text, #2c313a);
+  --hljs-string: $quarto-hl-st-color;
+  --hljs-number: $quarto-hl-num-color;
+  --hljs-title: $quarto-hl-fu-color;
+  --hljs-built_in: $quarto-hl-bu-color;
+  --hljs-keyword: $quarto-hl-kw-color;
+  --hljs-function: $quarto-hl-fu-color;
+  --hljs-params: $quarto-hl-va-color;
+  --hljs-variable: $quarto-hl-va-color;
+  --hljs-comment: $quarto-hl-co-color;
 }
 
 // $quarto-hl-im-color: #F76E48;
@@ -407,6 +419,94 @@ code span.vs {
 
 code span.wa {
   color: $quarto-hl-wa-color;
+}
+
+/* Highlight.js support */
+code.hljs,
+pre code.hljs {
+  background-color: var(--hljs-background, var(--color-code-bg));
+  color: var(--hljs-text, inherit);
+}
+
+pre code.hljs {
+  display: block;
+}
+
+.hljs::selection,
+.hljs ::selection {
+  background-color: var(--hljs-selection, rgba(0, 0, 0, 0.08));
+  color: inherit;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: var(--hljs-comment, var(--quarto-hl-co-color));
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst,
+.hljs-section {
+  color: var(--hljs-keyword, var(--quarto-hl-kw-color));
+}
+
+.hljs-title,
+.hljs-name,
+.hljs-attr,
+.hljs-attribute,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-type {
+  color: var(--hljs-title, var(--quarto-hl-fu-color));
+}
+
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+  color: var(--hljs-built_in, var(--quarto-hl-bu-color));
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-deletion,
+.hljs-meta,
+.hljs-meta .hljs-number {
+  color: var(--hljs-number, var(--quarto-hl-num-color));
+}
+
+.hljs-string,
+.hljs-doctag,
+.hljs-regexp,
+.hljs-link {
+  color: var(--hljs-string, var(--quarto-hl-st-color));
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-template-tag,
+.hljs-property {
+  color: var(--hljs-variable, var(--quarto-hl-va-color));
+}
+
+.hljs-function,
+.hljs-title .hljs-title,
+.hljs-function .hljs-title {
+  color: var(--hljs-function, var(--quarto-hl-fu-color));
+}
+
+.hljs-params {
+  color: var(--hljs-params, var(--quarto-hl-va-color));
+}
+
+.hljs-strong {
+  font-weight: 600;
+}
+
+.hljs-emphasis {
+  font-style: italic;
 }
 
 .prevent-inlining {

--- a/quarto/_format.yml
+++ b/quarto/_format.yml
@@ -38,9 +38,7 @@ format:
     html-math-method: katex
     footnotes-hover: true
     section-divs: true
-    highlight-style:
-      light: github
-      dark: github-dark
+    highlight-style: null
     css:
       # - css/colors-oklch.min.css
       # - css/custom.css
@@ -99,6 +97,16 @@ format:
           <!-- Google Tag Manager (noscript) -->
           <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TC329HJ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <!-- End Google Tag Manager (noscript) -->
+    include-after-body:
+      - text: | # Highlight.js
+          <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-jy5nBnLsmJWYNN2/Ji+IRDigMKzl6GpAp7i8HP14KrU3xSR99ZvobmHxR1uU1kk9tRYRmtuyGqj1ZTx8qE4fpQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+          <script>
+            window.addEventListener('DOMContentLoaded', () => {
+              if (window.hljs?.highlightAll) {
+                window.hljs.highlightAll();
+              }
+            });
+          </script>
     # header-includes: |
     #   <link href="https://iosevka-webfonts.github.io/iosevka/iosevka.css" rel="stylesheet">
     #   <link href="https://iosevka-webfonts.github.io/iosevkafixed/IosevkaFixed.css" rel="stylesheet">
@@ -203,9 +211,7 @@ format:
     html-math-method: katex
     footnotes-hover: true
     section-divs: true
-    highlight-style:
-      light: github
-      dark: github-dark
+    highlight-style: null
     css:
       # - css/colors-oklch.min.css
       # - css/custom.css
@@ -264,6 +270,16 @@ format:
           <!-- Google Tag Manager (noscript) -->
           <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TC329HJ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <!-- End Google Tag Manager (noscript) -->
+    include-after-body:
+      - text: | # Highlight.js
+          <script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-jy5nBnLsmJWYNN2/Ji+IRDigMKzl6GpAp7i8HP14KrU3xSR99ZvobmHxR1uU1kk9tRYRmtuyGqj1ZTx8qE4fpQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+          <script>
+            window.addEventListener('DOMContentLoaded', () => {
+              if (window.hljs?.highlightAll) {
+                window.hljs.highlightAll();
+              }
+            });
+          </script>
     # header-includes: |
     #   <link href="https://iosevka-webfonts.github.io/iosevka/iosevka.css" rel="stylesheet">
     #   <link href="https://iosevka-webfonts.github.io/iosevkafixed/IosevkaFixed.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- disable Pandoc syntax highlighting for HTML outputs and load Highlight.js once per page
- add a Highlight.js initialization snippet that runs after the document finishes loading
- extend the light and dark syntax stylesheets to define Highlight.js token colors so they match the existing palette

## Testing
- `quarto check` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebad86c080832a98c185e80a86f007

## Summary by Sourcery

Switch code highlighting to Highlight.js by disabling Pandoc’s built-in styles, injecting the Highlight.js script with an initialization snippet, and updating light and dark CSS themes to style the Highlight.js token classes to match the existing palette.

Enhancements:
- Disable built-in Pandoc highlight-style in the format configuration and include the Highlight.js CDN script with a post-load initialization snippet.
- Extend light and dark syntax stylesheets with CSS variables and rules to style Highlight.js token classes using the existing color palette.