### PR TITLE
Follow-ups to #8: review-comment fixes + banner domain rename

### DIFF
--- a/_include/deprecation-banner.html
+++ b/_include/deprecation-banner.html
@@ -1,4 +1,4 @@
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -47,7 +47,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -89,8 +89,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/_include/deprecation-banner.html
+++ b/_include/deprecation-banner.html
@@ -17,6 +17,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -113,11 +124,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -261,6 +261,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -357,11 +368,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -242,7 +242,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -291,7 +291,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -333,8 +333,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/ideas/index.html
+++ b/docs/ideas/index.html
@@ -235,7 +235,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating nav-fixed quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -284,7 +284,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -326,8 +326,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/ideas/index.html
+++ b/docs/ideas/index.html
@@ -254,6 +254,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -350,11 +361,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/index.html
+++ b/docs/index.html
@@ -346,6 +346,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -442,11 +453,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/index.html
+++ b/docs/index.html
@@ -327,7 +327,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-fixed fullcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -376,7 +376,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -418,8 +418,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/more/index.html
+++ b/docs/more/index.html
@@ -258,6 +258,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -354,11 +365,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/more/index.html
+++ b/docs/more/index.html
@@ -239,7 +239,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -288,7 +288,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -330,8 +330,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/now/index.html
+++ b/docs/now/index.html
@@ -240,7 +240,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -289,7 +289,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -331,8 +331,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/now/index.html
+++ b/docs/now/index.html
@@ -259,6 +259,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -355,11 +366,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/04/28/index.html
+++ b/docs/posts/2025/04/28/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/04/28/index.html
+++ b/docs/posts/2025/04/28/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/05/03/index.html
+++ b/docs/posts/2025/05/03/index.html
@@ -261,6 +261,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -357,11 +368,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/05/03/index.html
+++ b/docs/posts/2025/05/03/index.html
@@ -242,7 +242,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -291,7 +291,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -333,8 +333,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/06/01/index.html
+++ b/docs/posts/2025/06/01/index.html
@@ -264,6 +264,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -360,11 +371,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/06/01/index.html
+++ b/docs/posts/2025/06/01/index.html
@@ -245,7 +245,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -294,7 +294,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -336,8 +336,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/06/02/index.html
+++ b/docs/posts/2025/06/02/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/06/02/index.html
+++ b/docs/posts/2025/06/02/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/06/14/index.html
+++ b/docs/posts/2025/06/14/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/06/14/index.html
+++ b/docs/posts/2025/06/14/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/06/index.html
+++ b/docs/posts/2025/06/index.html
@@ -293,6 +293,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -389,11 +400,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/06/index.html
+++ b/docs/posts/2025/06/index.html
@@ -274,7 +274,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -323,7 +323,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -365,8 +365,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/09/12/index.html
+++ b/docs/posts/2025/09/12/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/09/12/index.html
+++ b/docs/posts/2025/09/12/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/09/17/index.html
+++ b/docs/posts/2025/09/17/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/09/17/index.html
+++ b/docs/posts/2025/09/17/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/09/torchtitan-blendcorpus/index.html
+++ b/docs/posts/2025/09/torchtitan-blendcorpus/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/09/torchtitan-blendcorpus/index.html
+++ b/docs/posts/2025/09/torchtitan-blendcorpus/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/10/06/index.html
+++ b/docs/posts/2025/10/06/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/10/06/index.html
+++ b/docs/posts/2025/10/06/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/11/12/index.html
+++ b/docs/posts/2025/11/12/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2025/11/12/index.html
+++ b/docs/posts/2025/11/12/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/index.html
+++ b/docs/posts/2025/index.html
@@ -293,6 +293,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -389,11 +400,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2025/index.html
+++ b/docs/posts/2025/index.html
@@ -274,7 +274,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -323,7 +323,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -365,8 +365,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2026/01/07/index.html
+++ b/docs/posts/2026/01/07/index.html
@@ -2108,7 +2108,7 @@ window.Quarto = {
 <li><p><a href="https://arxiv.org/abs/2509.13523"><strong>AERIS</strong>: Argonne Earth Systems Model for Reliable and Skillful Predictions</a> (<span class="citation" data-cites="stock2025aeris">Hatanpää et al. (<a href="#ref-stock2025aeris" role="doc-biblioref">2025</a>)</span>).</p>
 <p>Foundation models for Earth system science, pushing on coupled modeling, uncertainty, and long-horizon prediction. Additional details can be found in some of my recent talks:</p>
 <ul>
-<li><p><a href="https://samforeman.me/talks/2026/10/08/">AERIS: Argonne’s Earth Systems Model</a></p></li>
+<li><p><a href="https://samforeman.me/talks/2025/10/08/">AERIS: Argonne’s Earth Systems Model</a></p></li>
 <li><p><a href="https://samforeman.me/talks/2025/10/24/">Training Foundation Models on Supercomputers</a></p></li>
 </ul></li>
 <li><p>🍋 <a href="https://saforem2.github.io/ezpz"><code>ezpz</code></a>: A growing collection of utilities for launching, instrumenting, and debugging distributed jobs on real HPC systems.<br>
@@ -2717,7 +2717,7 @@ Foreman, Sam. 2026. <span>“🎉 Happy New Year!”</span> January 7. <a href="
 <span id="cb1-28"><a href="#cb1-28"></a>  uncertainty, and long-horizon prediction.</span>
 <span id="cb1-29"><a href="#cb1-29"></a>  Additional details can be found in some of my recent talks:</span>
 <span id="cb1-30"><a href="#cb1-30"></a></span>
-<span id="cb1-31"><a href="#cb1-31"></a><span class="ss">  - </span><span class="co">[</span><span class="ot">AERIS: Argonne’s Earth Systems Model</span><span class="co">](https://samforeman.me/talks/2026/10/08/)</span></span>
+<span id="cb1-31"><a href="#cb1-31"></a><span class="ss">  - </span><span class="co">[</span><span class="ot">AERIS: Argonne’s Earth Systems Model</span><span class="co">](https://samforeman.me/talks/2025/10/08/)</span></span>
 <span id="cb1-32"><a href="#cb1-32"></a></span>
 <span id="cb1-33"><a href="#cb1-33"></a><span class="ss">  - </span><span class="co">[</span><span class="ot">Training Foundation Models on Supercomputers</span><span class="co">](https://samforeman.me/talks/2025/10/24/)</span></span>
 <span id="cb1-34"><a href="#cb1-34"></a></span>

--- a/docs/posts/2026/01/07/index.html
+++ b/docs/posts/2026/01/07/index.html
@@ -266,7 +266,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -315,7 +315,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -357,8 +357,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2026/01/07/index.html
+++ b/docs/posts/2026/01/07/index.html
@@ -285,6 +285,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -381,11 +392,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2026/01/10/index.html
+++ b/docs/posts/2026/01/10/index.html
@@ -248,7 +248,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -297,7 +297,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -339,8 +339,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/2026/01/10/index.html
+++ b/docs/posts/2026/01/10/index.html
@@ -267,6 +267,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -363,11 +374,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/2026/01/10/index.html
+++ b/docs/posts/2026/01/10/index.html
@@ -2142,7 +2142,7 @@ section Intel
     Incremental Intel GPU improvements begin           :int2, 2024-07-24,
     Native Intel GPU support announced in PyTorch 2.5  :int3, 2024-10-17,
     Intel GPU eager and compile parity in PyTorch 2.7  :int4, 2025-04-23,
-    Intel XCCL Backend introduced in PyTorch 2.8       :int5, 2025-04-23,
+    Intel XCCL Backend introduced in PyTorch 2.8       :int5, 2025-08-06,
     IPEX discontinued                                  :int6, 2025-08-06, 2026-03-31
     IPEX end of life                                   :int7, 2026-03-31,
 

--- a/docs/posts/AuroraGPT/aurora-gpt/index.html
+++ b/docs/posts/AuroraGPT/aurora-gpt/index.html
@@ -264,6 +264,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -360,11 +371,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/aurora-gpt/index.html
+++ b/docs/posts/AuroraGPT/aurora-gpt/index.html
@@ -245,7 +245,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -294,7 +294,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -336,8 +336,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/checkpoints/index.html
+++ b/docs/posts/AuroraGPT/checkpoints/index.html
@@ -260,6 +260,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -356,11 +367,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/checkpoints/index.html
+++ b/docs/posts/AuroraGPT/checkpoints/index.html
@@ -241,7 +241,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -290,7 +290,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -332,8 +332,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/determinstic-flash-attn/index.html
+++ b/docs/posts/AuroraGPT/determinstic-flash-attn/index.html
@@ -264,6 +264,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -360,11 +371,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/determinstic-flash-attn/index.html
+++ b/docs/posts/AuroraGPT/determinstic-flash-attn/index.html
@@ -245,7 +245,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -294,7 +294,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -336,8 +336,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/flash-attn-sunspot/index.html
+++ b/docs/posts/AuroraGPT/flash-attn-sunspot/index.html
@@ -264,6 +264,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -360,11 +371,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/flash-attn-sunspot/index.html
+++ b/docs/posts/AuroraGPT/flash-attn-sunspot/index.html
@@ -245,7 +245,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -294,7 +294,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -336,8 +336,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/index.html
+++ b/docs/posts/AuroraGPT/index.html
@@ -266,7 +266,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -315,7 +315,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -357,8 +357,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/index.html
+++ b/docs/posts/AuroraGPT/index.html
@@ -285,6 +285,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -381,11 +392,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/long-sequences/index.html
+++ b/docs/posts/AuroraGPT/long-sequences/index.html
@@ -266,6 +266,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -362,11 +373,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/long-sequences/index.html
+++ b/docs/posts/AuroraGPT/long-sequences/index.html
@@ -247,7 +247,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -296,7 +296,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -338,8 +338,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/mpi4py-reproducer/index.html
+++ b/docs/posts/AuroraGPT/mpi4py-reproducer/index.html
@@ -261,6 +261,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -357,11 +368,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/mpi4py-reproducer/index.html
+++ b/docs/posts/AuroraGPT/mpi4py-reproducer/index.html
@@ -242,7 +242,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -291,7 +291,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -333,8 +333,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/spike-skipper/index.html
+++ b/docs/posts/AuroraGPT/spike-skipper/index.html
@@ -250,7 +250,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -299,7 +299,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -341,8 +341,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/spike-skipper/index.html
+++ b/docs/posts/AuroraGPT/spike-skipper/index.html
@@ -269,6 +269,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -365,11 +376,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/AuroraGPT/startup-times/index.html
+++ b/docs/posts/AuroraGPT/startup-times/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/AuroraGPT/startup-times/index.html
+++ b/docs/posts/AuroraGPT/startup-times/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/diffusion/index.html
+++ b/docs/posts/ai-for-physics/diffusion/index.html
@@ -244,7 +244,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -293,7 +293,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -335,8 +335,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ai-for-physics/diffusion/index.html
+++ b/docs/posts/ai-for-physics/diffusion/index.html
@@ -263,6 +263,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -359,11 +370,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/index.html
+++ b/docs/posts/ai-for-physics/index.html
@@ -252,6 +252,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -348,11 +359,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/index.html
+++ b/docs/posts/ai-for-physics/index.html
@@ -233,7 +233,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -282,7 +282,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -324,8 +324,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ai-for-physics/l2hmc-qcd/2dU1/index.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/2dU1/index.html
@@ -244,7 +244,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -293,7 +293,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -335,8 +335,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ai-for-physics/l2hmc-qcd/2dU1/index.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/2dU1/index.html
@@ -263,6 +263,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -359,11 +370,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/l2hmc-qcd/4dSU3nb/index-broken.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/4dSU3nb/index-broken.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ai-for-physics/l2hmc-qcd/4dSU3nb/index-broken.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/4dSU3nb/index-broken.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/l2hmc-qcd/index.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/index.html
@@ -252,6 +252,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -348,11 +359,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ai-for-physics/l2hmc-qcd/index.html
+++ b/docs/posts/ai-for-physics/l2hmc-qcd/index.html
@@ -233,7 +233,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -282,7 +282,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -324,8 +324,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/aurora-frameworks-2025-numpy-2/index.html
+++ b/docs/posts/aurora-frameworks-2025-numpy-2/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/aurora-frameworks-2025-numpy-2/index.html
+++ b/docs/posts/aurora-frameworks-2025-numpy-2/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/cooling-down-checkpoints/index.html
+++ b/docs/posts/cooling-down-checkpoints/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/cooling-down-checkpoints/index.html
+++ b/docs/posts/cooling-down-checkpoints/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/dope-slides/index.html
+++ b/docs/posts/dope-slides/index.html
@@ -256,7 +256,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -305,7 +305,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -347,8 +347,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/dope-slides/index.html
+++ b/docs/posts/dope-slides/index.html
@@ -275,6 +275,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -371,11 +382,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/drafts/2025/09/22/index.html
+++ b/docs/posts/drafts/2025/09/22/index.html
@@ -278,6 +278,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -374,11 +385,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/drafts/2025/09/22/index.html
+++ b/docs/posts/drafts/2025/09/22/index.html
@@ -259,7 +259,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -308,7 +308,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -350,8 +350,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ezpz-at-alcf/index.html
+++ b/docs/posts/ezpz-at-alcf/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/ezpz-at-alcf/index.html
+++ b/docs/posts/ezpz-at-alcf/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ezpz-v1/index.html
+++ b/docs/posts/ezpz-v1/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/ezpz-v1/index.html
+++ b/docs/posts/ezpz-v1/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -269,7 +269,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -318,7 +318,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -360,8 +360,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -288,6 +288,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -384,11 +395,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/jupyter/index.html
+++ b/docs/posts/jupyter/index.html
@@ -252,6 +252,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -348,11 +359,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/jupyter/index.html
+++ b/docs/posts/jupyter/index.html
@@ -233,7 +233,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -282,7 +282,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -324,8 +324,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/jupyter/l2hmc-4dSU3/index.html
+++ b/docs/posts/jupyter/l2hmc-4dSU3/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/jupyter/l2hmc-4dSU3/index.html
+++ b/docs/posts/jupyter/l2hmc-4dSU3/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/jupyter/l2hmc/4dSU3/index.html
+++ b/docs/posts/jupyter/l2hmc/4dSU3/index.html
@@ -244,7 +244,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -293,7 +293,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -335,8 +335,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/jupyter/l2hmc/4dSU3/index.html
+++ b/docs/posts/jupyter/l2hmc/4dSU3/index.html
@@ -263,6 +263,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -359,11 +370,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/jupyter/test/index.html
+++ b/docs/posts/jupyter/test/index.html
@@ -264,6 +264,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -360,11 +371,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/jupyter/test/index.html
+++ b/docs/posts/jupyter/test/index.html
@@ -245,7 +245,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -294,7 +294,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -336,8 +336,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/nice-headings/index.html
+++ b/docs/posts/nice-headings/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/nice-headings/index.html
+++ b/docs/posts/nice-headings/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/pbs-tui/index.html
+++ b/docs/posts/pbs-tui/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/pbs-tui/index.html
+++ b/docs/posts/pbs-tui/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/playing-with-mermaid/index.html
+++ b/docs/posts/playing-with-mermaid/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/playing-with-mermaid/index.html
+++ b/docs/posts/playing-with-mermaid/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/resume/index.html
+++ b/docs/posts/resume/index.html
@@ -282,6 +282,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -378,11 +389,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/resume/index.html
+++ b/docs/posts/resume/index.html
@@ -263,7 +263,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -312,7 +312,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -354,8 +354,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/svgbob/index.html
+++ b/docs/posts/svgbob/index.html
@@ -246,7 +246,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -295,7 +295,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -337,8 +337,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/svgbob/index.html
+++ b/docs/posts/svgbob/index.html
@@ -265,6 +265,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -361,11 +372,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/torchtitan-blendcorpus/index.html
+++ b/docs/posts/torchtitan-blendcorpus/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/torchtitan-blendcorpus/index.html
+++ b/docs/posts/torchtitan-blendcorpus/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/torchtune-aurora/index.html
+++ b/docs/posts/torchtune-aurora/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/torchtune-aurora/index.html
+++ b/docs/posts/torchtune-aurora/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/posts/torchtune-patch-aurora/index.html
+++ b/docs/posts/torchtune-patch-aurora/index.html
@@ -262,6 +262,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -358,11 +369,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/posts/torchtune-patch-aurora/index.html
+++ b/docs/posts/torchtune-patch-aurora/index.html
@@ -243,7 +243,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -292,7 +292,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -334,8 +334,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -257,6 +257,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -353,11 +364,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -238,7 +238,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -287,7 +287,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -329,8 +329,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/resume/index.html
+++ b/docs/resume/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/resume/index.html
+++ b/docs/resume/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/static/files/oneapi-talk/index.html
+++ b/docs/static/files/oneapi-talk/index.html
@@ -1,5 +1,5 @@
 <!doctype html><html xmlns="http://www.w3.org/1999/xhtml"><head><title>Keynote</title><meta name="viewport" content="initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,width=device-width"/><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/></head><body id="body" bgcolor="black">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -48,7 +48,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -90,8 +90,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/static/files/oneapi-talk/index.html
+++ b/docs/static/files/oneapi-talk/index.html
@@ -18,6 +18,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -114,11 +125,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/09/24/index.html
+++ b/docs/talks/2025/09/24/index.html
@@ -295,6 +295,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -391,11 +402,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/09/24/index.html
+++ b/docs/talks/2025/09/24/index.html
@@ -276,7 +276,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -325,7 +325,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -367,8 +367,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/2025/10/08/index.html
+++ b/docs/talks/2025/10/08/index.html
@@ -290,6 +290,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -386,11 +397,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/10/08/index.html
+++ b/docs/talks/2025/10/08/index.html
@@ -271,7 +271,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -320,7 +320,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -362,8 +362,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/2025/10/15/index.html
+++ b/docs/talks/2025/10/15/index.html
@@ -276,7 +276,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -325,7 +325,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -367,8 +367,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/2025/10/15/index.html
+++ b/docs/talks/2025/10/15/index.html
@@ -295,6 +295,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -391,11 +402,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/10/15/slides.html
+++ b/docs/talks/2025/10/15/slides.html
@@ -299,7 +299,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">Training Foundation Models on Supercomputers</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">Training Foundation Models on Supercomputers</h1>
                 <div class="flex-container" style="flex-direction: row; gap: 0.5rem; justify-content: space-between; align-items: flex-end;">
             <div style="">
                                 <!-- <p class="author" style="color: hsla(0, 0%, 93%, 1.0); font-weight: 600; font-size: 120%; margin-block-end: 0.5em;">Sam Foreman</p> -->

--- a/docs/talks/2025/10/24/index.html
+++ b/docs/talks/2025/10/24/index.html
@@ -276,7 +276,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -325,7 +325,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -367,8 +367,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/2025/10/24/index.html
+++ b/docs/talks/2025/10/24/index.html
@@ -295,6 +295,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -391,11 +402,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/10/24/slides.html
+++ b/docs/talks/2025/10/24/slides.html
@@ -300,7 +300,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">Training Foundation Models on Supercomputers</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">Training Foundation Models on Supercomputers</h1>
                 <div class="flex-container" style="flex-direction: row; gap: 0.5rem; justify-content: space-between; align-items: flex-end;">
             <div style="">
                                 <!-- <p class="author" style="color: hsla(0, 0%, 93%, 1.0); font-weight: 600; font-size: 120%; margin-block-end: 0.5em;">Sam Foreman</p> -->

--- a/docs/talks/2025/12/16/index.html
+++ b/docs/talks/2025/12/16/index.html
@@ -292,6 +292,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -388,11 +399,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/12/16/index.html
+++ b/docs/talks/2025/12/16/index.html
@@ -273,7 +273,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -322,7 +322,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -364,8 +364,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/2025/12/16/slides.html
+++ b/docs/talks/2025/12/16/slides.html
@@ -300,7 +300,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">AuroraGPT: Training Foundation Models on Supercomputers</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">AuroraGPT: Training Foundation Models on Supercomputers</h1>
                 <div class="flex-container" style="flex-direction: row; gap: 0.5rem; justify-content: space-between; align-items: flex-end;">
             <div style="">
                                 <!-- <p class="author" style="color: hsla(0, 0%, 93%, 1.0); font-weight: 600; font-size: 120%; margin-block-end: 0.5em;">Sam Foreman</p> -->

--- a/docs/talks/2025/aeris/index.html
+++ b/docs/talks/2025/aeris/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/2025/aeris/index.html
+++ b/docs/talks/2025/aeris/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/AuroraGPT-SIAM25/index.html
+++ b/docs/talks/AuroraGPT-SIAM25/index.html
@@ -292,6 +292,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -388,11 +399,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/AuroraGPT-SIAM25/index.html
+++ b/docs/talks/AuroraGPT-SIAM25/index.html
@@ -273,7 +273,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -322,7 +322,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -364,8 +364,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/AuroraGPT/alcf-hpc-workshop-2024/index.html
+++ b/docs/talks/AuroraGPT/alcf-hpc-workshop-2024/index.html
@@ -291,6 +291,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -387,11 +398,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/AuroraGPT/alcf-hpc-workshop-2024/index.html
+++ b/docs/talks/AuroraGPT/alcf-hpc-workshop-2024/index.html
@@ -272,7 +272,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -321,7 +321,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -363,8 +363,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/ai-for-science-2024/index.html
+++ b/docs/talks/ai-for-science-2024/index.html
@@ -295,6 +295,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -391,11 +402,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/ai-for-science-2024/index.html
+++ b/docs/talks/ai-for-science-2024/index.html
@@ -276,7 +276,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -325,7 +325,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -367,8 +367,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/ai-for-science-2024/tetris/index.html
+++ b/docs/talks/ai-for-science-2024/tetris/index.html
@@ -26,6 +26,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -122,11 +133,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/ai-for-science-2024/tetris/index.html
+++ b/docs/talks/ai-for-science-2024/tetris/index.html
@@ -7,7 +7,7 @@
 
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -56,7 +56,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -98,8 +98,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/alcf-hands-on-hpc-2025/index.html
+++ b/docs/talks/alcf-hands-on-hpc-2025/index.html
@@ -33,6 +33,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -129,11 +140,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/alcf-hands-on-hpc-2025/index.html
+++ b/docs/talks/alcf-hands-on-hpc-2025/index.html
@@ -14,7 +14,7 @@
   </script>
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -63,7 +63,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -105,8 +105,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/alcf-hpc-workshop-2024/index.html
+++ b/docs/talks/alcf-hpc-workshop-2024/index.html
@@ -294,6 +294,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -390,11 +401,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/alcf-hpc-workshop-2024/index.html
+++ b/docs/talks/alcf-hpc-workshop-2024/index.html
@@ -275,7 +275,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -324,7 +324,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -366,8 +366,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/aurora-gpt-fm-for-electric-grid/index.html
+++ b/docs/talks/aurora-gpt-fm-for-electric-grid/index.html
@@ -291,6 +291,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -387,11 +398,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/aurora-gpt-fm-for-electric-grid/index.html
+++ b/docs/talks/aurora-gpt-fm-for-electric-grid/index.html
@@ -272,7 +272,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -321,7 +321,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -363,8 +363,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/hpc-user-forum/index.html
+++ b/docs/talks/hpc-user-forum/index.html
@@ -291,6 +291,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -387,11 +398,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/hpc-user-forum/index.html
+++ b/docs/talks/hpc-user-forum/index.html
@@ -272,7 +272,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -321,7 +321,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -363,8 +363,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/incite-hackathon-2025/AuroraGPT/index.html
+++ b/docs/talks/incite-hackathon-2025/AuroraGPT/index.html
@@ -292,6 +292,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -388,11 +399,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/incite-hackathon-2025/AuroraGPT/index.html
+++ b/docs/talks/incite-hackathon-2025/AuroraGPT/index.html
@@ -273,7 +273,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -322,7 +322,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -364,8 +364,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/incite-hackathon-2025/ezpz/index.html
+++ b/docs/talks/incite-hackathon-2025/ezpz/index.html
@@ -251,7 +251,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -300,7 +300,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -342,8 +342,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/incite-hackathon-2025/ezpz/index.html
+++ b/docs/talks/incite-hackathon-2025/ezpz/index.html
@@ -270,6 +270,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -366,11 +377,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/incite-hackathon-2025/index.html
+++ b/docs/talks/incite-hackathon-2025/index.html
@@ -240,7 +240,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -289,7 +289,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -331,8 +331,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/incite-hackathon-2025/index.html
+++ b/docs/talks/incite-hackathon-2025/index.html
@@ -259,6 +259,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -355,11 +366,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/index.html
+++ b/docs/talks/index.html
@@ -269,7 +269,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -318,7 +318,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -360,8 +360,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/index.html
+++ b/docs/talks/index.html
@@ -288,6 +288,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -384,11 +395,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/lattice23/index.html
+++ b/docs/talks/lattice23/index.html
@@ -242,6 +242,17 @@ dynamics update that can be trained to improve sampling efficiency.
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -338,11 +349,24 @@ dynamics update that can be trained to improve sampling efficiency.
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/lattice23/index.html
+++ b/docs/talks/lattice23/index.html
@@ -223,7 +223,7 @@ dynamics update that can be trained to improve sampling efficiency.
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -272,7 +272,7 @@ dynamics update that can be trained to improve sampling efficiency.
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -314,8 +314,8 @@ dynamics update that can be trained to improve sampling efficiency.
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/llms-at-scale/index.html
+++ b/docs/talks/llms-at-scale/index.html
@@ -291,6 +291,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -387,11 +398,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/llms-at-scale/index.html
+++ b/docs/talks/llms-at-scale/index.html
@@ -272,7 +272,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -321,7 +321,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -363,8 +363,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/llms-on-polaris/index.html
+++ b/docs/talks/llms-on-polaris/index.html
@@ -268,7 +268,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -317,7 +317,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -359,8 +359,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/llms-on-polaris/index.html
+++ b/docs/talks/llms-on-polaris/index.html
@@ -287,6 +287,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -383,11 +394,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/openskai25/ai4science/index.html
+++ b/docs/talks/openskai25/ai4science/index.html
@@ -292,6 +292,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -388,11 +399,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/openskai25/ai4science/index.html
+++ b/docs/talks/openskai25/ai4science/index.html
@@ -273,7 +273,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating slimcontent quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -322,7 +322,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -364,8 +364,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/openskai25/index.html
+++ b/docs/talks/openskai25/index.html
@@ -240,7 +240,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -289,7 +289,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -331,8 +331,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/openskai25/index.html
+++ b/docs/talks/openskai25/index.html
@@ -259,6 +259,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -355,11 +366,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/openskai25/training/index.html
+++ b/docs/talks/openskai25/training/index.html
@@ -295,6 +295,17 @@ window.Quarto = {
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -391,11 +402,24 @@ window.Quarto = {
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/openskai25/training/index.html
+++ b/docs/talks/openskai25/training/index.html
@@ -276,7 +276,7 @@ window.Quarto = {
 </head>
 
 <body class="nav-sidebar floating quarto-dark">
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -325,7 +325,7 @@ window.Quarto = {
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -367,8 +367,8 @@ window.Quarto = {
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/docs/talks/openskai25/training/tetris/index.html
+++ b/docs/talks/openskai25/training/tetris/index.html
@@ -26,6 +26,17 @@
     color: var(--bs-body-color, #dee2e6);
     border-bottom: 1px solid var(--bs-border-color, rgba(131,131,131,0.7));
   }
+  /* Quarto's sticky-footer container is sized `min-height: calc(100vh - 132px)`
+     (132px = its reserve for navbar + footer). The in-flow banner adds its own
+     height on top of that, so the page overflows the viewport by the banner
+     height and the footer drops below the fold. Subtract the banner's real
+     height (measured into --samonl-bh by the script below) from that reserve so
+     the page fits again. Fallback 2.6rem covers the default banner height if a
+     browser lacks :has() support or the script hasn't run yet. Harmless on
+     layouts that don't use the 132px formula. */
+  body:has(#samonl-deprecation-banner) .quarto-container {
+    min-height: calc(100vh - 132px - var(--samonl-bh, 2.6rem));
+  }
   #samonl-deprecation-banner a {
     color: var(--bs-link-color, #82b1ff);
     text-decoration: underline;
@@ -122,11 +133,24 @@
     btn.textContent = '✕'; // ✕
     btn.addEventListener('click', function () {
       banner.remove();
+      // Banner gone: drop the height reservation so .quarto-container reclaims
+      // the space (footer returns to its original position).
+      document.documentElement.style.removeProperty('--samonl-bh');
       try { localStorage.setItem(STORAGE_KEY, '1'); } catch (e) {}
     });
     banner.appendChild(btn);
 
     document.body.insertBefore(banner, document.body.firstChild);
+
+    // Publish the banner's real rendered height so the .quarto-container
+    // min-height override (see <style>) subtracts exactly the right amount,
+    // independent of root font-size / zoom.
+    var setH = function () {
+      document.documentElement.style.setProperty(
+        '--samonl-bh', banner.offsetHeight + 'px');
+    };
+    setH();
+    if (window.addEventListener) window.addEventListener('resize', setH);
   }
 
   if (document.body) build();

--- a/docs/talks/openskai25/training/tetris/index.html
+++ b/docs/talks/openskai25/training/tetris/index.html
@@ -7,7 +7,7 @@
 
 </head>
 <body>
-<!-- Deprecation banner: announces move to sam.onl with a per-page link.
+<!-- Deprecation banner: announces move to samf.sh with a per-page link.
      Injected on every HTML page via format.html.include-before-body.
      Self-contained: no external assets. Excluded from reveal.js decks. -->
 <style>
@@ -56,7 +56,7 @@
   try { if (localStorage.getItem(STORAGE_KEY) === '1') return; } catch (e) {}
 
   function resolveSamOnl(pathname) {
-    var HOME = 'https://sam.onl';
+    var HOME = 'https://samf.sh';
     var key = pathname || '/';
     if (key.endsWith('/index.html')) key = key.slice(0, -'/index.html'.length);
     else if (key.endsWith('.html')) key = key.slice(0, -'.html'.length);
@@ -98,8 +98,8 @@
     var msg = document.createElement('span');
     msg.appendChild(document.createTextNode('📦 This site has moved to '));
     var home = document.createElement('a');
-    home.href = 'https://sam.onl';
-    home.textContent = 'sam.onl';
+    home.href = 'https://samf.sh';
+    home.textContent = 'samf.sh';
     msg.appendChild(home);
     msg.appendChild(document.createTextNode('.'));
 

--- a/plans/2026-06-26-deprecation-banner.md
+++ b/plans/2026-06-26-deprecation-banner.md
@@ -1,5 +1,10 @@
 # Deprecation Banner Implementation Plan
 
+> **Superseded 2026-06-29:** the new site was renamed `sam.onl` → `samf.sh`
+> (repo `saforem2/sam.onl` → `saforem2/samf.sh`). The live banner, resolver,
+> tests, and rendered `docs/` now use `samf.sh`. This plan is kept as the
+> original implementation record; read every `sam.onl` below as `samf.sh`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a dismissible banner to the top of every page on the old Quarto site (`samforeman.me`) announcing the move to `sam.onl`, with a link to the *corresponding* page on the new site.

--- a/plans/inject-banner.py
+++ b/plans/inject-banner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Inject the sam.onl deprecation banner partial into rendered docs/ HTML.
+"""Inject the samf.sh deprecation banner partial into rendered docs/ HTML.
 
 Why this exists: a full `quarto render` is impractically slow in this working
 copy (Quarto walks ~210k files). The banner is identical static HTML on every

--- a/plans/update-banner.py
+++ b/plans/update-banner.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Replace an already-injected deprecation banner block with the current
+_include/deprecation-banner.html content, in place, across docs/**/*.html.
+
+Use this after editing the partial (e.g. CSS tweaks) to propagate the change
+to the already-rendered pages without a full quarto render. Idempotent: a page
+whose banner already matches the partial is left byte-identical.
+
+The injected block runs from the start-of-banner HTML comment through the
+closing </script> of the banner IIFE. We match that span and swap it for the
+freshly-read partial. reveal.js decks never had a banner, so they're skipped
+naturally (no marker present).
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PARTIAL = REPO / "_include" / "deprecation-banner.html"
+DOCS = REPO / "docs"
+
+# The banner block always starts with this exact comment line and ends with
+# the IIFE's closing </script>. Both the old and new partials share the start
+# comment text (domain aside) — match either sam.onl or samf.sh to be safe.
+START_RE = re.compile(
+    r"<!-- Deprecation banner: announces move to (?:sam\.onl|samf\.sh) with a per-page link\."
+)
+# End marker: the unique final line of the script, then its closing tag.
+END_MARK = "})();\n</script>"
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    partial = PARTIAL.read_text(encoding="utf-8").strip() + "\n"
+
+    updated = skipped_nomarker = unchanged = 0
+    changed = []
+    for path in sorted(DOCS.rglob("*.html")):
+        if "site_libs" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        m = START_RE.search(text)
+        if not m:
+            skipped_nomarker += 1
+            continue
+        start = m.start()
+        end_idx = text.find(END_MARK, start)
+        if end_idx == -1:
+            skipped_nomarker += 1
+            continue
+        end = end_idx + len(END_MARK)
+        old_block = text[start:end]
+        new_text = text[:start] + partial.rstrip("\n") + text[end:]
+        if new_text == text:
+            unchanged += 1
+            continue
+        if not check:
+            path.write_text(new_text, encoding="utf-8")
+        updated += 1
+        changed.append(str(path.relative_to(REPO)))
+
+    verb = "would update" if check else "updated"
+    print(f"{verb}: {updated}")
+    print(f"unchanged (already current): {unchanged}")
+    print(f"skipped (no banner marker): {skipped_nomarker}")
+    if check:
+        for c in changed:
+            print(f"  {c}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/url-resolver.mjs
+++ b/plans/url-resolver.mjs
@@ -1,8 +1,8 @@
-// Pure resolver: old samforeman.me pathname -> { url, hasPageLink } on sam.onl.
+// Pure resolver: old samforeman.me pathname -> { url, hasPageLink } on samf.sh.
 // NOTE: keep this body byte-for-byte identical to the <script> in
 // _include/deprecation-banner.html. New site PRESERVES casing — do not lowercase.
 export function resolveSamOnl(pathname) {
-  const HOME = 'https://sam.onl';
+  const HOME = 'https://samf.sh';
 
   // 1. Normalize: drop /index.html or trailing .html, then trailing slash.
   let key = pathname || '/';

--- a/plans/url-resolver.test.mjs
+++ b/plans/url-resolver.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { resolveSamOnl } from './url-resolver.mjs';
 
-const HOME = 'https://sam.onl';
+const HOME = 'https://samf.sh';
 
 // --- identity (casing preserved) ---
 test('identity: simple post keeps path', () => {

--- a/posts/2026/01/07/index.qmd
+++ b/posts/2026/01/07/index.qmd
@@ -28,7 +28,7 @@ thinking about / working on.
   uncertainty, and long-horizon prediction.
   Additional details can be found in some of my recent talks:
 
-  - [AERIS: Argonne’s Earth Systems Model](https://samforeman.me/talks/2026/10/08/)
+  - [AERIS: Argonne’s Earth Systems Model](https://samforeman.me/talks/2025/10/08/)
 
   - [Training Foundation Models on Supercomputers](https://samforeman.me/talks/2025/10/24/)
 

--- a/posts/2026/01/10/roadmap.mmd
+++ b/posts/2026/01/10/roadmap.mmd
@@ -23,6 +23,6 @@ section Intel
     Incremental Intel GPU improvements begin           :int2, 2024-07-24,
     Native Intel GPU support announced in PyTorch 2.5  :int3, 2024-10-17,
     Intel GPU eager and compile parity in PyTorch 2.7  :int4, 2025-04-23,
-    Intel XCCL Backend introduced in PyTorch 2.8       :int5, 2025-04-23,
+    Intel XCCL Backend introduced in PyTorch 2.8       :int5, 2025-08-06,
     IPEX discontinued                                  :int6, 2025-08-06, 2026-03-31
     IPEX end of life                                   :int7, 2026-03-31,

--- a/posts/2026/01/10/timeline.mmd
+++ b/posts/2026/01/10/timeline.mmd
@@ -36,7 +36,7 @@ sequenceDiagram
     AMD->>PT: Jun 2024: MI300x PyTorch guidance (near drop-in CUDA-like experience)
     AMD->>PT: Oct 2024: Torchtune-on-AMD guide (LLM finetuning enablement)
     AMD->>PT: Sep 2025: Public preview PyTorch on Windows\n(RX 7000/9000, Ryzen AI no WSL2 workaround)
-    AMD->>PT: Nov 2025: AMD Software: PyTorch on Windows Edition 7.1.1<br>(ROCm 7.1.,1 update)
+    AMD->>PT: Nov 2025: AMD Software: PyTorch on Windows Edition 7.1.1<br>(ROCm 7.1.1 update)
 
     Intel->>PT: Apr 2025: PyTorch 2.7 solidifies Intel GPU support<br>(eager + torch.compile, Windows + Linux)
 

--- a/specs/2026-06-26-deprecation-banner-design.md
+++ b/specs/2026-06-26-deprecation-banner-design.md
@@ -1,5 +1,10 @@
 # Deprecation banner linking samforeman.me → sam.onl
 
+> **Superseded 2026-06-29:** the new site was renamed `sam.onl` → `samf.sh`
+> (repo `saforem2/sam.onl` → `saforem2/samf.sh`). The live banner, resolver,
+> tests, and rendered `docs/` now use `samf.sh`. This document is kept as the
+> original design record; read every `sam.onl` below as `samf.sh`.
+
 **Date:** 2026-06-26
 **Status:** Approved design, pending implementation plan
 

--- a/talks/2025/10/15/title-slide.html
+++ b/talks/2025/10/15/title-slide.html
@@ -33,7 +33,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
         $if(subtitle)$
         <h2 class="subtitle" style="color: hsla(0, 0%, 95%, 1.0); font-size: 150%;">$subtitle$</h2>
         $endif$

--- a/talks/2025/10/24/title-slide.html
+++ b/talks/2025/10/24/title-slide.html
@@ -34,7 +34,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
         $if(subtitle)$
         <h2 class="subtitle" style="color: hsla(0, 0%, 95%, 1.0); font-size: 150%;">$subtitle$</h2>
         $endif$

--- a/talks/2025/12/16/title-slide.html
+++ b/talks/2025/12/16/title-slide.html
@@ -35,7 +35,7 @@
         /* padding-bottom: 0.2em; */
         /* line-height: 1.5em!important; */
     ">
-        <h1 class="title" style="color: #000000; overflow-word-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
+        <h1 class="title" style="color: #000000; overflow-wrap: break-word; font-size: 175%; margin-block-end: 0.5lh;">$title$</h1>
         $if(subtitle)$
         <h2 class="subtitle" style="color: hsla(0, 0%, 95%, 1.0); font-size: 150%;">$subtitle$</h2>
         $endif$


### PR DESCRIPTION
Two related follow-ups to PR #8 (the deprecation-banner + mobile-perf merge).

## 1. Address PR #8 review comments (4 small fixes)
None were in the deprecation-banner code — all in the mobile-perf / source-tracking files.

| # | File | Fix |
|---|------|-----|
| 1 | `talks/2025/12/16/title-slide.html` | invalid `overflow-word-wrap` → `overflow-wrap: break-word` (+ rendered `docs/talks/2025/12/16/slides.html`) |
| 2 | `posts/2026/01/07/index.qmd` | AERIS talk link `/talks/2026/10/08/` (404) → `/talks/2025/10/08/` (+ rendered `docs/posts/2026/01/07/index.html`) |
| 3 | `posts/2026/01/10/timeline.mmd` | `ROCm 7.1.,1` typo → `ROCm 7.1.1` |
| 4 | `posts/2026/01/10/roadmap.mmd` | PyTorch 2.8 milestone mis-dated `2025-04-23` → `2025-08-06` (matches the release timeline in the same chart) |

The two **P1** findings (Bootstrap / Quarto-syntax CSS 404s) were already resolved by later commits on the PR #8 branch before merge — referenced hashed assets exist in `docs/site_libs/`. No action needed.

## 2. Rename deprecation-banner target `sam.onl` → `samf.sh`
The new site moved from `sam.onl` to `samf.sh` (repo `saforem2/sam.onl` → `saforem2/samf.sh`). Per-page paths are unchanged (same repo content), so only the domain + repo slug changed — the override table is untouched.

- `_include/deprecation-banner.html`: `HOME` url, link href, link text, comment.
- `plans/url-resolver.mjs` + `.test.mjs`: `HOME` constant (tests still 17/17 passing).
- `plans/inject-banner.py`: docstring.
- `docs/**/*.html` (70 already-injected pages): live banner domain swapped (isolated to the 4 banner lines per page; no render/CSS churn pulled in).
- `specs/` + `plans/` design docs: added a "superseded → samf.sh" note at the top, leaving the dated bodies as the original record.

## Test plan
- [x] `node --test plans/url-resolver.test.mjs` — 17/17 (asserts against `https://samf.sh`).
- [x] All 70 docs banners now point to `samf.sh`; 0 remaining `sam.onl` in rendered output.
- [ ] Confirm the 2025-12-16 title slide wraps correctly.
- [ ] Confirm the AERIS link resolves to the 2025/10/08 talk.
- [ ] Spot-check a live banner link resolves on `samf.sh` (couldn't verify from this session — network egress was sandboxed).